### PR TITLE
Dataset configuration refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea/
 venv/
+__pycache__
+results

--- a/config.py
+++ b/config.py
@@ -20,7 +20,8 @@ def load_config(path=None):
         _configparser.read(path)
 
     # data and paths
-    CONFIG['dataset'] = _configparser._sections['dataset']
+    CONFIG['dataset'] = _configparser.get('dataset', 'dataset')
+    CONFIG['dataset_path'] = _configparser.get('dataset', 'dataset_path')
     CONFIG['resultdir_path'] = _configparser.get('agent', 'resultdir_path', fallback='./results')
     CONFIG['agentdir_path'] = _configparser.get('agent', 'agentdir_path', fallback='./agent')
 

--- a/config.py
+++ b/config.py
@@ -20,9 +20,7 @@ def load_config(path=None):
         _configparser.read(path)
 
     # data and paths
-    CONFIG['jsonfile_path'] = _configparser.get('agent', 'jsonfile_path', fallback='')
-    CONFIG['imagefile_path'] = _configparser.get('agent', 'imagefile_path', fallback='../generated_data/image_locations.txt')
-    CONFIG['boxfile_path'] = _configparser.get('agent', 'boxfile_path', fallback='../generated_data/bounding_boxes.npy')
+    CONFIG['dataset'] = _configparser._sections['dataset']
     CONFIG['resultdir_path'] = _configparser.get('agent', 'resultdir_path', fallback='./results')
     CONFIG['agentdir_path'] = _configparser.get('agent', 'agentdir_path', fallback='./agent')
 

--- a/datasets.py
+++ b/datasets.py
@@ -1,0 +1,57 @@
+import json
+import os
+import numpy as np
+
+class Dataset:
+    id = 'noop'
+
+    def __init__(self, config):
+        config_prefix = f"{self.id}_dataset_"
+        self.config = {k.replace(config_prefix, ''): v for k, v in config.items() if config_prefix in k}
+
+    def data(self):
+        pass  
+
+class SimpleDataset(Dataset):
+    id = 'simple'
+
+    def data(self):
+        image_locations_file_path = self.config['image_locations']
+        dataset_base_path = os.path.dirname(image_locations_file_path)
+        
+        relative_image_paths = np.loadtxt(image_locations_file_path, dtype=str)
+        absolute_image_paths = [dataset_base_path + i.strip('.') for i in relative_image_paths]
+        
+        bounding_boxes = np.load(self.config['bounding_boxes'], allow_pickle=True)
+
+        return absolute_image_paths, bounding_boxes
+
+class SignDataset(Dataset):
+    id = 'sign'
+
+    def data(self):
+        config_file_path = self.config['config']
+        dataset_base_path = os.path.dirname(config_file_path)
+
+        absolute_image_paths = []
+        bounding_boxes = []
+
+        with open(config_file_path) as f:
+            data = json.load(f)
+            for image in data:
+                absolute_path = os.path.join(dataset_base_path, image['file_name'])
+                if not os.path.exists(absolute_path): continue
+                absolute_paths.append(absolute_path)
+                bboxes.append(list(image['bounding_boxes']))
+
+        return absolute_image_paths, bounding_boxes
+
+class SynthDataset(Dataset):
+    id = 'synth'
+
+    def data(self):
+        pass
+
+def get_dataset(id):
+    datasets = [SimpleDataset, SignDataset, SynthDataset]
+    return {Dataset.id: Dataset for Dataset in datasets}[id]

--- a/datasets.py
+++ b/datasets.py
@@ -48,11 +48,76 @@ class SynthTextDataset(Dataset):
     id = 'synthtext'
 
     def data(self):
+        """
+        mat file structure:
+        {
+            'imnames': [[path_1, path_2, ...]]
+            'wordBB': [
+                # image 1
+                [
+                    [
+                        [x0_txt0, x0_txt1, ...],
+                        [x1_txt0, x1_txt2, ...],
+                        [x2_txt0, x2_txt2, ...],
+                        [x3_txt0, x3_txt2, ...],
+                    ],
+                    [
+                        [y0_txt0, y0_txt1, ...],
+                        [y1_txt0, y1_txt2, ...],
+                        [y2_txt0, y2_txt2, ...],
+                        [y3_txt0, y3_txt2, ...],
+                    ],
+                    # but if there is only one text the format is:
+                    [x0, x1, x2, x3],
+                    [y0, y1, y2, y3],
+                ],
+                # image 2
+                [
+                    ...
+                ],
+                ...
+            ]
+        }
+
+        corner points (clockwise):
+        x0|y0 ---- x1|y1
+          .          .
+          .          .
+        x3|y3 ---- x2|y2
+        """
+
         mat_file = os.path.join(self.dataset_path, 'gt.mat')
         mat = sio.loadmat(mat_file)
         relative_image_paths = [arr[0] for arr in mat['imnames'][0]]
         absolute_image_paths = [os.path.join(self.dataset_path, image_path) for image_path in relative_image_paths]
-        bounding_boxes = mat['wordBB'][0]
+        bounding_boxes = []
+
+        print(f"Processing bounding boxes of the dataset...")
+
+        for i, image_bboxes in enumerate(mat['wordBB'][0]):
+            if i % 100000 == 99999:
+                print(f"Processed bounding boxes of {i + 1} images.")
+
+            output_bboxes = []
+
+            if hasattr(image_bboxes[0][0], "__len__"):
+                for index in range(len(image_bboxes[0][0])):
+                    x0 = image_bboxes[0][0][index]
+                    x1 = image_bboxes[0][1][index]
+                    x2 = image_bboxes[0][2][index]
+                    x3 = image_bboxes[0][3][index]
+                    y0 = image_bboxes[1][0][index]
+                    y1 = image_bboxes[1][1][index]
+                    y2 = image_bboxes[1][2][index]
+                    y3 = image_bboxes[1][3][index]
+                    output_bboxes.append([int(min(x0, x3)), int(min(y0, y1)), int(max(x1, x2)), int(max(y2, y3))])
+            else:
+                x0, x1, x2, x3 = image_bboxes[0]
+                y0, x1, x2, x3 = image_bboxes[1]
+                output_bboxes.append([int(min(x0, x3)), int(min(y0, y1)), int(max(x1, x2)), int(max(y2, y3))])
+            
+            bounding_boxes.append(output_bboxes)
+
         return absolute_image_paths, bounding_boxes
         
 def get_dataset(id):

--- a/datasets.py
+++ b/datasets.py
@@ -1,13 +1,13 @@
 import json
 import os
 import numpy as np
+import scipy.io as sio
 
 class Dataset:
     id = 'noop'
 
-    def __init__(self, config):
-        config_prefix = f"{self.id}_dataset_"
-        self.config = {k.replace(config_prefix, ''): v for k, v in config.items() if config_prefix in k}
+    def __init__(self, dataset_path):
+        self.dataset_path = os.path.abspath(dataset_path)
 
     def data(self):
         pass  
@@ -16,13 +16,12 @@ class SimpleDataset(Dataset):
     id = 'simple'
 
     def data(self):
-        image_locations_file_path = self.config['image_locations']
-        dataset_base_path = os.path.dirname(image_locations_file_path)
+        image_locations_file = os.path.join(self.dataset_path, 'image_locations.txt')
+        relative_image_paths = np.loadtxt(image_locations_file, dtype=str)
+        absolute_image_paths = [os.path.join(self.dataset_path, image_path) for image_path in relative_image_paths]
         
-        relative_image_paths = np.loadtxt(image_locations_file_path, dtype=str)
-        absolute_image_paths = [dataset_base_path + i.strip('.') for i in relative_image_paths]
-        
-        bounding_boxes = np.load(self.config['bounding_boxes'], allow_pickle=True)
+        bounding_boxes_file = os.path.join(self.dataset_path, 'bounding_boxes.npy')
+        bounding_boxes = np.load(bounding_boxes_file, allow_pickle=True)
 
         return absolute_image_paths, bounding_boxes
 
@@ -30,8 +29,7 @@ class SignDataset(Dataset):
     id = 'sign'
 
     def data(self):
-        config_file_path = self.config['config']
-        dataset_base_path = os.path.dirname(config_file_path)
+        config_file_path = os.path.join(self.dataset_path, 'training.json')
 
         absolute_image_paths = []
         bounding_boxes = []
@@ -39,19 +37,25 @@ class SignDataset(Dataset):
         with open(config_file_path) as f:
             data = json.load(f)
             for image in data:
-                absolute_path = os.path.join(dataset_base_path, image['file_name'])
+                absolute_path = os.path.join(self.dataset_path, image['file_name'])
                 if not os.path.exists(absolute_path): continue
                 absolute_paths.append(absolute_path)
                 bboxes.append(list(image['bounding_boxes']))
 
         return absolute_image_paths, bounding_boxes
 
-class SynthDataset(Dataset):
-    id = 'synth'
+class SynthTextDataset(Dataset):
+    id = 'synthtext'
 
     def data(self):
-        pass
-
+        mat_file = os.path.join(self.dataset_path, 'gt.mat')
+        mat = sio.loadmat(mat_file)
+        relative_image_paths = [arr[0] for arr in mat['imnames'][0]]
+        absolute_image_paths = [os.path.join(self.dataset_path, image_path) for image_path in relative_image_paths]
+        bounding_boxes = mat['wordBB'][0]
+        return absolute_image_paths, bounding_boxes
+        
 def get_dataset(id):
-    datasets = [SimpleDataset, SignDataset, SynthDataset]
+    datasets = [SimpleDataset, SignDataset, SynthTextDataset]
     return {Dataset.id: Dataset for Dataset in datasets}[id]
+  

--- a/evaluate.py
+++ b/evaluate.py
@@ -16,6 +16,7 @@ from PIL import Image
 from custom_model import CustomModel
 from config import CONFIG, print_config
 from actions import ACTIONS
+from datasets import get_dataset
 
 from chainerrl.misc.random_seed import set_random_seed
 
@@ -37,57 +38,7 @@ try:
 except ModuleNotFoundError:
     print('Object Detection Library not initialized correctly')
 
-
-class Dataset:
-    def __init__(self, image_paths, true_bboxes):
-        self.image_paths = image_paths
-        self.true_bboxes = true_bboxes
-
-    @classmethod
-    def from_json(cls, jsonfile_path):
-        absolute_paths, bboxes = [], []
-        images_base_path = os.path.dirname(jsonfile_path)
-        with open(jsonfile_path) as f:
-            data = json.load(f)
-            for example in data:
-                absolute_path = os.path.join(images_base_path, example['file_name'])
-                if os.path.exists(absolute_path):
-                    absolute_paths.append(absolute_path)
-                    bboxes.append(list(example['bounding_boxes']))
-        return cls(absolute_paths, bboxes)
-
-    @classmethod
-    def from_numpy(cls, imagefile_path, boxfile_path):
-        images_base_path = os.path.dirname(imagefile_path)
-        relative_paths = np.loadtxt(imagefile_path, dtype=str)
-        absolute_paths = [images_base_path + i.strip('.') for i in relative_paths]
-        if type(absolute_paths) is not list:
-            absolute_paths = [image_paths]
-        bboxes = np.load(boxfile_path, allow_pickle=True)
-        return cls(absolute_paths, bboxes)
-
-    def get(self, idx, as_image=True):
-        image = self.image_paths[idx]
-        if as_image:
-            image = Image.open(image)
-        true_bboxes = self.true_bboxes[idx]
-        return image, true_bboxes
-
-    def get_image_name(self, idx):
-        image_path, _ = self.get(idx, as_image=False)
-        image_fname = Path(image_path).name
-        image_name = image_fname.split('.')[0]
-        return image_name
-
-    def random_sample(self, as_image=True):
-        random_index = np.random.randint(len(self.image_paths))
-        return self.get(random_idx, as_image=as_image)
-
-    def __len__(self):
-        return len(self.image_paths)
-
-
-def create_agent_with_environment(actions, dataset, config,
+def create_agent_with_environment(actions, image_paths, bounding_boxes, config
     env_mode='test', gpu_id=-1, max_steps_per_image=200,
     # Training params needed to initialize chainer, but shouldn't matter for testing
     replay_buffer_capacity=20000, gamma=0.95, replay_start_size=100,
@@ -95,7 +46,7 @@ def create_agent_with_environment(actions, dataset, config,
 ):
     num_actions = len(actions)
     env = TextLocEnv(
-        dataset.image_paths, dataset.true_bboxes, mode=env_mode,
+        image_paths, bounding_boxes, mode=env_mode,
         premasking=False, playout_episode=True,
         max_steps_per_image=max_steps_per_image
     )
@@ -147,12 +98,13 @@ Set arguments w/ config file (--config) or cli
 def main(eval_dirname='evaluations', viz_dirname='episodes', images_dirname='images', plots_dirname='plots', max_sample_size=100):
     print_config()
 
-    if CONFIG['jsonfile_path']:
-        dataset = Dataset.from_json(CONFIG['jsonfile_path'])
-    else:
-        dataset = Dataset.from_numpy(CONFIG['imagefile_path'], CONFIG['boxfile_path'])
+    dataset_id = CONFIG['dataset']
+    dataset = get_dataset(dataset_id)(CONFIG['dataset_path'])
+    image_paths, bounding_boxes = dataset.data()
 
-    agent, env = create_agent_with_environment(ACTIONS, dataset, CONFIG)
+    agent, env = create_agent_with_environment(
+        ACTIONS, image_paths, bounding_boxes, config
+    )
 
     # Create new evaluation folder
     now_date = datetime.datetime.now()

--- a/example.ini
+++ b/example.ini
@@ -1,7 +1,6 @@
 [dataset]
 dataset=simple
-simple_dataset_image_locations=../dataset-generator/image_locations.txt
-simple_dataset_bounding_boxes=../dataset-generator/bounding_boxes.npy
+dataset_path=./dataset
 
 [agent]
 # seeds
@@ -11,7 +10,7 @@ seed_environment=20302
 resultdir_path=./results
 agentdir_path=./agent
 # hardware
-gpu_id=0
+gpu_id=-1
 # optimizer
 epsilon=0.01
 learning_rate=0.0001

--- a/example.ini
+++ b/example.ini
@@ -1,6 +1,6 @@
 [dataset]
-dataset=simple
-dataset_path=./dataset
+dataset=synthtext
+dataset_path=.
 
 [agent]
 # seeds

--- a/example.ini
+++ b/example.ini
@@ -1,6 +1,6 @@
 [dataset]
-dataset=synthtext
-dataset_path=.
+dataset=simple
+dataset_path=./dataset
 
 [agent]
 # seeds

--- a/example.ini
+++ b/example.ini
@@ -1,10 +1,13 @@
+[dataset]
+dataset=simple
+simple_dataset_image_locations=../dataset-generator/image_locations.txt
+simple_dataset_bounding_boxes=../dataset-generator/bounding_boxes.npy
+
 [agent]
 # seeds
 seed_agent=20301
 seed_environment=20302
-# data and paths
-boxfile_path=../dataset-generator/bounding_boxes.npy
-imagefile_path=../dataset-generator/image_locations.txt
+# paths
 resultdir_path=./results
 agentdir_path=./agent
 # hardware
@@ -13,7 +16,7 @@ gpu_id=0
 epsilon=0.01
 learning_rate=0.0001
 # agent
-gamma=0.1
+gamma=0.95
 replay_start_size=100
 replay_buffer_capacity=20000
 update_interval=1

--- a/train_agent.py
+++ b/train_agent.py
@@ -13,6 +13,7 @@ import time
 import re
 import json
 
+from datasets import get_dataset
 from custom_model import CustomModel
 from config import CONFIG, write_config, print_config
 from tensorboard_gradient_histogram import TensorboardGradientPlotter
@@ -30,30 +31,13 @@ def main():
     print_config()
 
     # Load dataset to initialize environment with
-    absolute_paths, bboxes = [], []
-    jsonfile_path = CONFIG.get('jsonfile_path')
+    dataset_id = CONFIG['dataset']['dataset']
+    dataset = get_dataset(dataset_id)(CONFIG['dataset'])
+    image_paths, bounding_boxes = dataset.data()
 
-    if jsonfile_path:
-        print(f'Loading data from {jsonfile_path}')
-        images_base_path = os.path.dirname(jsonfile_path)
-        with open(jsonfile_path) as f:
-            data = json.load(f)
-            for example in data:
-                absolute_path = os.path.join(images_base_path, example['file_name'])
-                if os.path.exists(absolute_path):
-                    absolute_paths.append(absolute_path)
-                    bboxes.append(list(example['bounding_boxes']))
-    else:
-        images_base_path = os.path.dirname(CONFIG['imagefile_path'])
-        relative_paths = np.loadtxt(CONFIG['imagefile_path'], dtype=str)
-        absolute_paths = [images_base_path + i.strip('.') for i in relative_paths]
-        bboxes = np.load(CONFIG['boxfile_path'], allow_pickle=True)
+    assert len(image_paths) == len(bounding_boxes)
 
-    assert len(absolute_paths) == len(bboxes)
-    print(f'Image base path: {images_base_path}')
-    print(f'#Images: {len(absolute_paths)}')
-
-    env = TextLocEnv(absolute_paths, bboxes)
+    env = TextLocEnv(image_paths, bounding_boxes)
 
     # Seed agent & environment seeds for reproducable experiments
     set_random_seed(CONFIG['seed_agent'], gpus=[CONFIG['gpu_id']])

--- a/train_agent.py
+++ b/train_agent.py
@@ -34,7 +34,7 @@ def main():
     dataset_id = CONFIG['dataset']
     dataset = get_dataset(dataset_id)(CONFIG['dataset_path'])
     image_paths, bounding_boxes = dataset.data()
-
+    
     assert len(image_paths) == len(bounding_boxes)
 
     env = TextLocEnv(image_paths, bounding_boxes)

--- a/train_agent.py
+++ b/train_agent.py
@@ -31,8 +31,8 @@ def main():
     print_config()
 
     # Load dataset to initialize environment with
-    dataset_id = CONFIG['dataset']['dataset']
-    dataset = get_dataset(dataset_id)(CONFIG['dataset'])
+    dataset_id = CONFIG['dataset']
+    dataset = get_dataset(dataset_id)(CONFIG['dataset_path'])
     image_paths, bounding_boxes = dataset.data()
 
     assert len(image_paths) == len(bounding_boxes)

--- a/visualize_agent.py
+++ b/visualize_agent.py
@@ -12,6 +12,7 @@ from PIL import Image
 
 from custom_model import CustomModel
 from config import CONFIG, print_config
+from datasets import get_dataset
 
 
 ACTION_MEANINGS = {
@@ -35,12 +36,11 @@ Set arguments w/ config file (--config) or cli
 def main():
     print_config()
 
-    relative_paths = np.loadtxt(CONFIG['imagefile_path'], dtype=str)
-    images_base_path = os.path.dirname(CONFIG['imagefile_path'])
-    absolute_paths = [images_base_path + i.strip('.') for i in relative_paths]
-    bboxes = np.load(CONFIG['boxfile_path'], allow_pickle=True)
+    dataset_id = CONFIG['dataset']
+    dataset = get_dataset(dataset_id)(CONFIG['dataset_path'])
+    image_paths, bounding_boxes = dataset.data()
 
-    env = TextLocEnv(absolute_paths, bboxes, -1)
+    env = TextLocEnv(image_paths, bounding_boxes)
     q_func = chainerrl.q_functions.SingleModelStateQFunctionWithDiscreteAction(CustomModel(9))
     optimizer = chainer.optimizers.Adam(eps=1e-2)
     optimizer.setup(q_func)

--- a/visualize_agent_graph.py
+++ b/visualize_agent_graph.py
@@ -15,6 +15,7 @@ import chainer.computational_graph as c
 
 from custom_model import CustomModel
 from config import CONFIG, print_config
+from datasets import get_dataset
 
 
 """
@@ -24,12 +25,11 @@ Set arguments w/ config file (--config) or cli
 def main():
     print_config()
 
-    relative_paths = np.loadtxt(CONFIG['imagefile_path'], dtype=str)
-    images_base_path = os.path.dirname(CONFIG['imagefile_path'])
-    absolute_paths = [images_base_path + i.strip('.') for i in relative_paths]
-    bboxes = np.load(CONFIG['boxfile_path'], allow_pickle=True)
+    dataset_id = CONFIG['dataset']
+    dataset = get_dataset(dataset_id)(CONFIG['dataset_path'])
+    image_paths, bounding_boxes = dataset.data()
 
-    env = TextLocEnv(absolute_paths, bboxes, -1)
+    env = TextLocEnv(image_paths, bounding_boxes)
     m = CustomModel(10)
     vs = [m(env.reset())]
     g = c.build_computational_graph(vs)


### PR DESCRIPTION
With this PR, configuring different (and new) datasets is easier.
There is a new section in the .ini config file called `[dataset]`.
You can specify one of in `datasets.py` predefined datasets by their id and add dataset specific configration by adding a prefix with the dataset name:
```
[dataset]
dataset=simple
dataset_path=./dataset
``` 

To configure a new dataset, make a class in `datasets.py` that inherits the `Dataset` class and implements a `load()` method which sets the `self.image_paths` and `self.bounding_boxes` properties.

```python
class MyDataset(Dataset):
    id = 'my'

    def load(self):
        self.image_paths = ...
        self.bounding_boxes = ....
```

This PR already contains dataset classes for the simple and sign dataset which can be configured with the id `simple`, `sign` or `synthtext`. 